### PR TITLE
Fixes permission check

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="" />
+        <option name="gradleJvm" value="21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,18 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyMandatoryEncodingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" editorAttributes="INFO_ATTRIBUTES" />
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="telegram.message.Message.__await__" />
+        </list>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TEXT ATTRIBUTES" enabled_by_default="false" editorAttributes="TYPO">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -9,7 +9,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.jeff_media'
-version = '1.0.5'
+version = '1.0.6'
 
 repositories {
     maven { url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
@@ -30,7 +30,7 @@ processResources {
     }
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     testLogging {
         events "passed", "skipped", "failed"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,10 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.spigotmc:spigot-api:1.21.3-R0.1-SNAPSHOT'
-    implementation 'net.kyori:adventure-text-minimessage:4.21.0'
-    implementation 'net.kyori:adventure-text-serializer-legacy:4.21.0'
-    implementation 'net.kyori:adventure-platform-bukkit:4.3.1'
+    compileOnly 'org.spigotmc:spigot-api:1.21.7-R0.1-SNAPSHOT'
+    implementation 'net.kyori:adventure-text-minimessage:4.24.0'
+    implementation 'net.kyori:adventure-text-serializer-legacy:4.24.0'
+    implementation 'net.kyori:adventure-platform-bukkit:4.4.1'
 }
 
 processResources {

--- a/src/main/java/com/jeff_media/anvilcolors/command/ReloadCommand.java
+++ b/src/main/java/com/jeff_media/anvilcolors/command/ReloadCommand.java
@@ -17,7 +17,7 @@ public class ReloadCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         plugin.reloadConfig();
-        // just being lazy here. I would replace the &a color code but I'd rather
+        // just being lazy here. I would replace the &a color code, but I'd rather
         // convert it using the miniMessage serializer than screw anything up
         String miniMessage = Formatter.colorize("&aAnvilColors reloaded");
         String legacyMessage = Formatter.miniMessageToLegacy(miniMessage);

--- a/src/main/java/com/jeff_media/anvilcolors/listener/AnvilListener.java
+++ b/src/main/java/com/jeff_media/anvilcolors/listener/AnvilListener.java
@@ -34,18 +34,16 @@ public class AnvilListener implements Listener {
         List<HumanEntity> viewers = event.getViewers();
         if (viewers.size() != 1)
             return;
-        HumanEntity humanEntity = viewers.get(0);
-        if (!(humanEntity instanceof Player))
+        HumanEntity humanEntity = viewers.getFirst();
+        if (!(humanEntity instanceof Player player))
             return;
-        Player player = (Player) humanEntity;
 
         if (!(player.hasPermission("anvilcolors.color") || player.hasPermission("anvilcolors.color.*"))) {
             return;
         }
 
-        boolean allowFormatting = player.isPermissionSet("anvilcolors.format")
-                && player.hasPermission("anvilcolors.format")
-                || player.isPermissionSet("anvilcolors.format.*") && player.hasPermission("anvilcolors.format.*");
+        boolean allowFormatting = player.hasPermission("anvilcolors.format") ||
+                player.hasPermission("anvilcolors.format.*");
 
         ItemStack item = event.getResult();
 
@@ -57,15 +55,14 @@ public class AnvilListener implements Listener {
         if (!meta.hasDisplayName())
             return;
 
-        if (!(event.getView() instanceof AnvilView))
-            return;
-        AnvilView anvilView = (AnvilView) event.getView();
+        event.getView();
+        AnvilView anvilView = event.getView();
         String renameText = anvilView.getRenameText();
         if (renameText == null || renameText.isEmpty())
             return;
         boolean hasMiniMessageTags = Formatter.containsMiniMessageTags(renameText);
         String displayName;
-        int replacedColors = 0;
+        int replacedColors;
 
         RenameResult result = formatter.colorize(player, renameText, plugin.getItalicsMode());
         String processedText = result.getColoredName();

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -45,7 +45,7 @@ require-permissions: false
 ####################
 
 # In vanilla, items renamed on an anvil are always in italics. The reset code (&r) or
-# color codes however remove the italics. You can use this option to force italics
+# color codes, however, remove the italics. You can use this option to force italics
 # on all renamed items, or to remove the vanilla italics.
 #
 # Available options:


### PR DESCRIPTION
Instead of checking to see if the permission is set AND also true, we instead just check to see if the permissions is true. This fixes cases where a player might inherit the AnvilColors permission, which makes it true, but may not have it overridden themselves. This causes the permissions check to fail when it really shouldn't.